### PR TITLE
Make TweetViewHolder public

### DIFF
--- a/tweet-ui/src/main/java/com/twitter/sdk/android/tweetui/TweetTimelineRecyclerViewAdapter.java
+++ b/tweet-ui/src/main/java/com/twitter/sdk/android/tweetui/TweetTimelineRecyclerViewAdapter.java
@@ -148,7 +148,7 @@ public class TweetTimelineRecyclerViewAdapter extends
         return timelineDelegate.getCount();
     }
 
-    protected static final class TweetViewHolder extends RecyclerView.ViewHolder {
+    public static final class TweetViewHolder extends RecyclerView.ViewHolder {
         public TweetViewHolder(CompactTweetView itemView) {
             super(itemView);
         }


### PR DESCRIPTION
When I override `TweetTimelineRecyclerViewAdapter` in Kotlin, i got an error like `'public' function exposes its 'protected (in TweetTimelineRecyclerViewAdapter)' return type TweetViewHolder` in the `onCreateViewHolder` method:

```kotlin
class TweetsRecyclerViewAdapter(context: Context,
                                timeline: Timeline<Tweet>,
                                styleResId: Int,
                                callback: Callback<Tweet>?): TweetTimelineRecyclerViewAdapter(context, timeline, styleResId, callback) {

    override fun onCreateViewHolder(parent: ViewGroup?, viewType: Int): TweetViewHolder {
        val tweet = TweetBuilder().build()
        val compactTweetView = CompactTweetView(context, tweet, styleResId)
        compactTweetView.setOnActionCallback(actionCallback)
        return TweetViewHolder(compactTweetView)
    }

}
```

It's because the inner class `TweetViewHolder` has a `protected` modifier, whereas the method `onCreateViewHolder` has a `public` modifier.
Kotlin compiler prohibits to expose a protected member in a public method, and I think it's a good practice to do so in Java, too.
So please consider to make TweetViewHolder public.