### PR TITLE
Fix incorrect license information of pom

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,8 +3,8 @@ org.gradle.jvmargs=-Xms1024m -Xmx2048m -XX:MaxPermSize=1024m
 org.gradle.parallel=false
 org.gradle.configureondemand=true
 
-pom_licence_name=TwitterKit Agreement
-pom_licence_url=https://dev.twitter.com/overview/terms/twitterkit.html
+pom_licence_name=The Apache Software License, Version 2.0
+pom_licence_url=http://www.apache.org/licenses/LICENSE-2.0.txt
 pom_licence_distribution=repo
 
 pom_organization=Twitter


### PR DESCRIPTION
Twitter Kit for Android is licensed [under Apache Licenses 2.0](https://github.com/twitter/twitter-kit-android#license). But pom file indicate that `TwitterKit Agreement` licenses.

```xml
  <licenses>
    <license>
      <name>TwitterKit Agreement</name>
      <url>https://dev.twitter.com/overview/terms/twitterkit.html</url>
      <distribution>repo</distribution>
    </license>
  </licenses>
```

I'm not sure how pom file is genarated in this project. But I found incorrect information in `gradle.properites`, and fix it.
