### PR TITLE
Update Picasso library to 2.71828

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -34,7 +34,7 @@ ext {
             dexmakerMockito            : 'com.linkedin.dexmaker:dexmaker-mockito:2.2.0',
 
             // Other
-            picasso                    : 'com.squareup.picasso:picasso:2.5.2',
+            picasso                    : 'com.squareup.picasso:picasso:2.71828',
             supportCompatV4            : 'com.android.support:support-compat:26.1.0',
             supportCoreV4              : 'com.android.support:support-core-ui:26.1.0',
             retrofit                   : 'com.squareup.retrofit2:retrofit:2.3.0',

--- a/tweet-composer/src/main/java/com/twitter/sdk/android/tweetcomposer/ComposerView.java
+++ b/tweet-composer/src/main/java/com/twitter/sdk/android/tweetcomposer/ComposerView.java
@@ -68,7 +68,7 @@ public class ComposerView extends LinearLayout {
     }
 
     private void init(Context context) {
-        imageLoader = Picasso.with(getContext());
+        imageLoader = Picasso.get();
         // TODO: make color vary depending on the style
         mediaBg = new ColorDrawable(context.getResources()
                 .getColor(R.color.tw__composer_light_gray));

--- a/tweet-ui/src/main/java/com/twitter/sdk/android/tweetui/GalleryAdapter.java
+++ b/tweet-ui/src/main/java/com/twitter/sdk/android/tweetui/GalleryAdapter.java
@@ -63,7 +63,7 @@ class GalleryAdapter extends PagerAdapter {
         container.addView(root);
 
         final MediaEntity entity = items.get(position);
-        Picasso.with(context).load(entity.mediaUrlHttps).into(root);
+        Picasso.get().load(entity.mediaUrlHttps).into(root);
 
         return root;
     }

--- a/tweet-ui/src/main/java/com/twitter/sdk/android/tweetui/TweetUi.java
+++ b/tweet-ui/src/main/java/com/twitter/sdk/android/tweetui/TweetUi.java
@@ -63,7 +63,7 @@ public class TweetUi {
         guestSessionProvider = twitterCore.getGuestSessionProvider();
         tweetRepository = new TweetRepository(new Handler(Looper.getMainLooper()),
                 twitterCore.getSessionManager());
-        imageLoader = Picasso.with(Twitter.getInstance().getContext(getIdentifier()));
+        imageLoader = Picasso.get();
     }
 
     public String getIdentifier() {


### PR DESCRIPTION
This is to prevent conflict with the latest Picasso version. Picasso removed it's `with(Context)` function and replace it with `get()`.